### PR TITLE
Make it possible to not stop execution after a given amount of steps

### DIFF
--- a/grift/src/GRIFT/Simulation.hs
+++ b/grift/src/GRIFT/Simulation.hs
@@ -327,7 +327,7 @@ stepRVLog iset = do
 runRV' ::
   (RVStateM m rv, KnownRV rv, w ~ RVWidth rv, 32 <= w) =>
   InstructionSet rv -> Int -> Int -> m Int
-runRV' _ currSteps maxSteps | currSteps >= maxSteps = return currSteps
+runRV' _ currSteps maxSteps | maxSteps /= 0 && currSteps >= maxSteps = return currSteps
 runRV' iset currSteps maxSteps = do
   halted <- isHalted
   if halted


### PR DESCRIPTION
If I am not mistaken, there is currently no way to disable the *"stop after N steps"* feature. This commit allows disabling this feature by passing a zero value to the `-s` option. This is best combined with the `--halt-pc` option. That is, an invocation along the lines of

    $ grift-sim --halt-pc 0x00011ce8 -s 0 my-binary.elf

will ensure that `grift-sim` only terminates **iff** it reaches PC `0x00011ce8`.

I also think that `-s 0` would be a better default than `-s 10000` but refrained from changing the default since this would be a backwards-incompatible change.