### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/grift-doc/grift-doc.cabal
+++ b/grift-doc/grift-doc.cabal
@@ -22,7 +22,7 @@ executable grift-doc
                      , base >= 4.7 && < 5
                      , bv-sized >= 1.0.2 && < 1.0.6
                      , bv-sized-float >= 0.2 && < 0.3
-                     , bytestring >= 0.10.8 && < 0.12
+                     , bytestring >= 0.10.8 && < 0.13
                      , containers >= 0.5.11 && < 0.7
                      , elf-edit
                      , filepath >= 1.4 && < 1.5

--- a/grift-sim/grift-sim.cabal
+++ b/grift-sim/grift-sim.cabal
@@ -23,7 +23,7 @@ executable grift-sim
                      , base >= 4.7 && < 5
                      , bv-sized >= 1.0.2 && < 1.0.6
                      , bv-sized-float >= 0.2 && < 0.3
-                     , bytestring >= 0.10.8 && < 0.12
+                     , bytestring >= 0.10.8 && < 0.13
                      , containers >= 0.5.11 && < 0.7
                      , elf-edit
                      , filepath >= 1.4 && < 1.5

--- a/grift/grift.cabal
+++ b/grift/grift.cabal
@@ -36,7 +36,7 @@ library
                      , base >= 4.7 && < 5
                      , bv-sized >= 1.0.2 && < 1.0.6
                      , bv-sized-float >= 0.2 && < 0.3
-                     , bytestring >= 0.10.8 && < 0.12
+                     , bytestring >= 0.10.8 && < 0.13
                      , containers >= 0.5.11 && < 0.7
                      -- , crucible
                      -- , crucible-llvm


### PR DESCRIPTION
This:

* Bumps the `bytestring` upper version bounds to allow building with `bytestring-0.12.*`, which is bundled with GHC 9.8.
* Bumps the `bv-sized` submodule to bring in the changes from https://github.com/GaloisInc/bv-sized/pull/29, which allows `bv-sized` to build with GHC 9.8